### PR TITLE
Update button class to fix auto skip

### DIFF
--- a/skip_netflix_intro.js
+++ b/skip_netflix_intro.js
@@ -5,7 +5,7 @@ const callback = function(mutations, observer) {
 		// Iterate over all added nodes in a mutation
 		for (let node of mutation.addedNodes) {
 			// Click on node if it
-			if (node.matches('.skip-credits')) {
+			if (node.matches('.watch-video--skip-content-button')) {
 				node.firstChild.click();
 			}
 		}


### PR DESCRIPTION
Netflix recently updated their player UI and the skip intro button class changed from `.skip-credits` to `.watch-video--skip-content-button`.

This PR updates the class to re-enable auto skipping.