### PR TITLE
Update target class to fix autoskip

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,21 @@
 {
   "manifest_version": 2,
   "name": "Skip Netflix Intro",
-  "version": "1.1",
-
+  "version": "1.2",
   "description": "Addon to automatically skip intros on Netflix",
-  
   "applications": {
     "gecko": {
       "id": "skip_netflix_intro@jonas-hellmann.de"
     }
   },
-
   "content_scripts": [
     {
-      "matches": ["*://*.netflix.com/*"],
-      "js": ["skip_netflix_intro.js"]
+      "matches": [
+        "*://*.netflix.com/*"
+      ],
+      "js": [
+        "skip_netflix_intro.js"
+      ]
     }
   ]
-
 }

--- a/skip_netflix_intro.js
+++ b/skip_netflix_intro.js
@@ -1,16 +1,16 @@
 // Create observer with callback function
-const callback = function(mutations, observer) {
-	// Iterate over every DOM mutation
-	for (let mutation of mutations) {
-		// Iterate over all added nodes in a mutation
-		for (let node of mutation.addedNodes) {
-			// Click on node if it
-			if (node.matches('.watch-video--skip-content-button')) {
-				node.firstChild.click();
-			}
-		}
-	}
-};	
+const callback = function (mutations, observer) {
+    // Iterate over every DOM mutation
+    for (let mutation of mutations) {
+        // Iterate over all added nodes in a mutation
+        for (let node of mutation.addedNodes) {
+            // Click on node if it
+            if (node.matches('.watch-video--skip-content')) {
+                node.firstChild.click();
+            }
+        }
+    }
+};
 const mutationObserver = new MutationObserver(callback);
 
 // Start oberserving every change in the DOM


### PR DESCRIPTION
My last PR was not targeting the correct DOM element; sorry for the _rushed_ changes, which I did not test.

I updated the target class from `.watch-video--skip-content-button` to `.watch-video--skip-content` which now correctly selects the parent element of the **Skip Intro** button. To verify the changes I tested the extension locally via the Firefox debugger.

PS: I updated the version to `1.2` so you don't have to.